### PR TITLE
chore: bump prek hooks and GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/job-coverage-comment.yml
+++ b/.github/workflows/job-coverage-comment.yml
@@ -11,12 +11,12 @@ jobs:
             pull-requests: write
         steps:
             - name: Download coverage artifact
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@v8
               with:
                   name: coverage-report
 
             - name: Generate coverage comment
-              uses: actions/github-script@v7
+              uses: actions/github-script@v8
               with:
                   script: |
                       const fs = require('fs');

--- a/.github/workflows/job-prek.yml
+++ b/.github/workflows/job-prek.yml
@@ -10,10 +10,10 @@ jobs:
         env:
             PIP_DISABLE_PIP_VERSION_CHECK: 1
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
 
             - name: Install uv
-              uses: astral-sh/setup-uv@v5
+              uses: astral-sh/setup-uv@v7
               with:
                   version: latest
                   enable-cache: true
@@ -25,7 +25,7 @@ jobs:
             - name: Install the project
               run: uv sync --all-extras --dev
 
-            - uses: actions/cache@v4
+            - uses: actions/cache@v5
               with:
                   path: ~/.cache/prek
                   key: prek-3|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}

--- a/.github/workflows/job-test.yml
+++ b/.github/workflows/job-test.yml
@@ -11,10 +11,10 @@ jobs:
             contents: read
             id-token: write
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
 
             - name: Install uv
-              uses: astral-sh/setup-uv@v5
+              uses: astral-sh/setup-uv@v7
               with:
                   version: latest
                   enable-cache: true
@@ -31,7 +31,7 @@ jobs:
 
             - name: Upload coverage artifact
               if: always()
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: coverage-report
                   path: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ default_stages: [pre-commit, pre-push]
 repos:
     - repo: https://github.com/astral-sh/uv-pre-commit
       # uv version.
-      rev: 0.10.7
+      rev: 0.10.12
       hooks:
           - id: uv-lock
     - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -32,7 +32,7 @@ repos:
           - id: yamlfmt
             exclude: ^{{cookiecutter.project_slug}}/.pre-commit-config.yaml$
     - repo: https://github.com/psf/black
-      rev: 26.1.0
+      rev: 26.3.1
       hooks:
           - id: black
             language_version: python3
@@ -50,7 +50,7 @@ repos:
             language: system
             types: [python]
     - repo: https://github.com/codespell-project/codespell
-      rev: v2.4.1
+      rev: v2.4.2
       hooks:
           - id: codespell
             name: codespell

--- a/{{cookiecutter.project_slug}}/.github/workflows/job-coverage-comment.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/job-coverage-comment.yml
@@ -11,12 +11,12 @@ jobs:
             pull-requests: write
         steps:
             - name: Download coverage artifact
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@v8
               with:
                   name: coverage-report
 
             - name: Generate coverage comment
-              uses: actions/github-script@v7
+              uses: actions/github-script@v8
               with:
                   script: |
                       const fs = require('fs');

--- a/{{cookiecutter.project_slug}}/.github/workflows/job-prek.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/job-prek.yml
@@ -10,10 +10,10 @@ jobs:
         env:
             PIP_DISABLE_PIP_VERSION_CHECK: 1
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
 
             - name: Install uv
-              uses: astral-sh/setup-uv@v5
+              uses: astral-sh/setup-uv@v7
               with:
                   version: latest
                   enable-cache: true
@@ -25,7 +25,7 @@ jobs:
             - name: Install the project
               run: uv sync --all-extras --dev
 
-            - uses: actions/cache@v4
+            - uses: actions/cache@v5
               with:
                   path: ~/.cache/prek
                   key: prek-3|{% raw %}${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}{% endraw %}

--- a/{{cookiecutter.project_slug}}/.github/workflows/job-test.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/job-test.yml
@@ -11,10 +11,10 @@ jobs:
             contents: read
             id-token: write
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
 
             - name: Install uv
-              uses: astral-sh/setup-uv@v5
+              uses: astral-sh/setup-uv@v7
               with:
                   version: latest
                   enable-cache: true
@@ -31,7 +31,7 @@ jobs:
 
             - name: Upload coverage artifact
               if: always()
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: coverage-report
                   path: |

--- a/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ default_stages: [pre-commit, pre-push]
 repos:
     - repo: https://github.com/astral-sh/uv-pre-commit
       # uv version.
-      rev: 0.10.7
+      rev: 0.10.12
       hooks:
           - id: uv-lock
     - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -30,7 +30,7 @@ repos:
       hooks:
           - id: yamlfmt
     - repo: https://github.com/psf/black
-      rev: 26.1.0
+      rev: 26.3.1
       hooks:
           - id: black
             language_version: python3
@@ -48,7 +48,7 @@ repos:
             language: system
             types: [python]
     - repo: https://github.com/codespell-project/codespell
-      rev: v2.4.1
+      rev: v2.4.2
       hooks:
           - id: codespell
             name: codespell


### PR DESCRIPTION
## Summary
- Ran `prek run autoupdate` to bump pre-commit hooks (both repos):
  - `uv-pre-commit`: 0.10.7 → 0.10.12
  - `black`: 26.1.0 → 26.3.1
  - `codespell`: v2.4.1 → v2.4.2
- Bumped GitHub Actions to latest major versions (both repos):
  - `actions/checkout`: v4 → v6
  - `actions/cache`: v4 → v5
  - `actions/upload-artifact`: v4 → v7
  - `actions/download-artifact`: v4 → v8
  - `actions/github-script`: v7 → v8
  - `astral-sh/setup-uv`: v5 → v7

## Test plan
- [ ] Verify CI passes (prek + tests)
- [ ] Verify coverage comment still posts correctly

🤖 Generated with [Claude Code](https://claude.ai/code)